### PR TITLE
Deleted typed arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,6 @@ abc
 |set|Set|Set|Set.new([1, 2, 3])|`#<Set:0x007fe46821dd98>`|
 |map|Hash|Hash|`{a: 1, b: 2, c: 3}`|`{:a=>1, :b=>2, :c=>3}`|
 |bytes|Transit::ByteArray|Transit::ByteArray|Transit::ByteArray.new("base64")|base64|
-|shorts|Transit::TaggedValue|Array|Transit::TaggedValue.new("shorts", [1, 2, 3])|[1, 2, 3]|
-|ints|Transit::TaggedValue|Array|Transit::TaggedValue.new("ints", [1, 2, 3])|[1, 2, 3]|
-|longs|Transit::TaggedValue|Array|Transit::TaggedValue.new("longs", [1, 2, 3])|[1, 2, 3]|
-|floats|Transit::TaggedValue|Array|Transit::TaggedValue.new("floats", [1.1, 2.2, 3.3])|[1.1, 2.2, 3.3]|
-|doubles|Transit::TaggedValue|Array|Transit::TaggedValue.new("doubles", [1.1, 2.2, 3.3])|[1.1, 2.2, 3.3]|
-|chars|Transit::TaggedValue|Array|Transit::TaggedValue.new("chars", ["a","b"])|["a","b"]|
-|bools|Transit::TaggedValue|Array|Transit::TaggedValue.new("bools", [false, false, true])|[false, false, true]|
 |link|Transit::Link|Transit::Link|Transit::Link.new(Addressable::URI.parse("http://example.org/search"), "search")|`#<Transit::Link:0x007f746c8715a8>`|
 
 ## Type Mapping

--- a/lib/transit/read_handlers.rb
+++ b/lib/transit/read_handlers.rb
@@ -88,13 +88,6 @@ module Transit
       "set"     => SetHandler.new,
       "link"    => LinkHandler.new,
       "list"    => IdentityHandler.new,
-      "shorts"  => IdentityHandler.new,
-      "ints"    => IdentityHandler.new,
-      "longs"   => IdentityHandler.new,
-      "floats"  => IdentityHandler.new,
-      "doubles" => IdentityHandler.new,
-      "bools"   => IdentityHandler.new,
-      "chars"   => IdentityHandler.new,
       "cmap"    => CmapHandler.new
     }.freeze
 

--- a/spec/transit/round_trip_spec.rb
+++ b/spec/transit/round_trip_spec.rb
@@ -141,13 +141,6 @@ module Transit
     round_trips("an array", [1,2,3], type)
     round_trips("a char", TaggedValue.new("c", "x"), type, :expected => "x")
     round_trips("a list", TaggedValue.new("list", [1,2,3]), type, :expected => [1,2,3])
-    round_trips("an array of shorts", TaggedValue.new("shorts", [1,2,3]), type, :expected => [1,2,3])
-    round_trips("an array of ints", TaggedValue.new("ints", [1,2,3]), type, :expected => [1,2,3])
-    round_trips("an array of longs", TaggedValue.new("longs", [1,2,3]), type, :expected => [1,2,3])
-    round_trips("an array of floats", TaggedValue.new("floats", [1.1,2.2,3.3]), type, :expected => [1.1,2.2,3.3])
-    round_trips("an array of doubles", TaggedValue.new("doubles", [1.1,2.2,3.3]), type, :expected => [1.1,2.2,3.3])
-    round_trips("an array of bools", TaggedValue.new("bools", [true,false,false,true]), type, :expected => [true,false,false,true])
-    round_trips("an array of chars", TaggedValue.new("chars", ["a","b","c"]), type, :expected => ["a","b","c"])
     round_trips("an array of maps w/ cacheable keys", [{"this" => "a"},{"this" => "b"}], type)
 
     round_trips("edge case chars", %w[` ~ ^ #], type)


### PR DESCRIPTION
We don't implement typed arrays at this moment. This pull request deletes all typed arrays handling from reader.
