### PR TITLE
Add Rubinius to Supported Rubies in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ for more info.
 ## Supported Rubies
 
 * MRI 1.9.3, 2.0.0, 2.1.0, 2.1.1, 2.1.2
+* Rubinius 2.2.10+
 
 ## Contributing
 


### PR DESCRIPTION
I ran the specs with Rubinius 2.2.10 and all passed as seen below.

Is there any interest in testing on Travis CI? If yes, I can send a PR to enable that as well.

Thanks!

```
$ bundle exec rspec
Run options: include {:focus=>true, :focused=>true}

All examples were filtered out; ignoring {:focus=>true, :focused=>true}
..........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 2.88 seconds (files took 4.01 seconds to load)
842 examples, 0 failures
```
