### PR TITLE
Fix nested caches

### DIFF
--- a/lib/transit/decoder.rb
+++ b/lib/transit/decoder.rb
@@ -54,7 +54,7 @@ module Transit
       case node
       when String
         if cache.has_key?(node)
-          cache.read(node)
+          decode(cache.read(node), cache, as_map_key)
         else
           parsed = if !node.start_with?(ESC)
                      node

--- a/lib/transit/decoder.rb
+++ b/lib/transit/decoder.rb
@@ -68,7 +68,7 @@ module Transit
                      @default_handler.from_rep(node[1], node[2..-1])
                    end
           if cache.cacheable?(node, as_map_key)
-            cache.write(parsed)
+            cache.write(node)
           end
           parsed
         end

--- a/spec/transit/nested_round_trip_spec.rb
+++ b/spec/transit/nested_round_trip_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+module Transit
+  MyPhoneNumber = Struct.new(:area, :number)
+  MyAddress = Struct.new(:street, :number)
+  MyPerson = Struct.new(:name, :address, :number)
+
+  class MyPhoneNumberHandler
+    def tag(_) "number" end
+    def rep(p) { "area" => p.area, "number" => p.number } end
+    def string_rep(_) nil end
+  end
+
+  class MyPhoneNumberReader
+    def from_rep(v)
+      MyPhoneNumber.new(v["area"], v["number"])
+    end
+  end
+
+  class MyAddressHandler
+    def tag(_) "address" end
+    def rep(a) { "street" => a.street, "number" => a.number } end
+    def string_rep(_) nil end
+  end
+
+  class MyAddressReader
+    def from_rep(v)
+      MyAddress.new(v["street"], v["number"])
+    end
+  end
+
+  class MyPersonHandler
+    def tag(_) "person" end
+    def rep(p) { "name" => p.name, "address" => p.address, "number" => p.number } end
+    def string_rep(_) nil end
+  end
+
+  class MyPersonReader
+    def from_rep(v)
+     MyPerson.new(v["name"], v["address"], v["number"])
+    end
+  end
+
+ 
+  context "rolling cache entries" do
+    let(:person){
+      MyPerson.new( "Elmo",
+                  MyAddress.new("Sesame str", 15),
+                  MyPhoneNumber.new("555", "12345678")
+                )
+    }
+
+    let(:read_handlers){
+      {
+        "number"  => MyPhoneNumberReader.new,
+        "address" => MyAddressReader.new,
+        "person"  => MyPersonReader.new
+      }
+    }
+
+    let(:write_handlers){
+      {
+        MyPhoneNumber => MyPhoneNumberHandler.new,
+        MyAddress => MyAddressHandler.new,
+        MyPerson => MyPersonHandler.new
+      }
+    }
+
+    let(:io){ StringIO.new }
+    let(:writer){ Transit::Writer.new(:json, io, handlers: write_handlers) }
+
+    it 'knows how to write and read again, correctly using the cache' do
+      writer.write(person)
+      encoded_person = io.string
+
+      reader = Transit::Reader.new(:json, StringIO.new(encoded_person), handlers: read_handlers)
+      restored_person = reader.read
+
+      expect(restored_person).to eq person
+    end
+  end
+end


### PR DESCRIPTION
Although Pull Requests are not accepted, it seemed to be the best way to describe the problem and its solution.

Only write the node to the cache when decoding (not the parsed value), because this is what the writer does as well. Writing the parsed value to the cache results in a different cache when reading. This only seems to be a problem when tag-names are used that are used as map values as well. In the original decoder, both '~#name' and 'name' would be stored as 'name', while the writer would store both '~#name' and 'name' separately

When we do this, it is necessary to apply #decode again on a string value from the cache, so we handle nested data as well.

Added a test case that would fail before, but now succeeds (while existing tests pass as well).