### PR TITLE
fix BigDecimal deprecation warning on ruby 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ for more info.
 |decimal|Float|Float|123.456|123.456|
 |keyword|Symbol|Symbol|:abc|:abc|
 |symbol|Transit::Symbol|Transit::Symbol|Transit::Symbol.new("foo")|`#<Transit::Symbol "foo">`|
-|big decimal|BigDecimal|BigDecimal|BigDecimal.new("2**64")|`#<BigDecimal:7f9e6d33c558>`|
+|big decimal|BigDecimal|BigDecimal|BigDecimal("2**64")|`#<BigDecimal:7f9e6d33c558>`|
 |big integer|Integer|Integer|2**128|340282366920938463463374607431768211456|
 |time|DateTime, Date, Time|DateTime|DateTime.now|`#<DateTime: 2014-07-15T15:52:27+00:00 ((2456854j,57147s,23000000n),+0s,2299161j)>`|
 |uri|Addressable::URI, URI|Addressable::URI|Addressable::URI.parse("http://example.com")|`#<Addressable::URI:0x3fc0e20390d4 URI:http://example.com>`|

--- a/lib/transit/read_handlers.rb
+++ b/lib/transit/read_handlers.rb
@@ -40,7 +40,7 @@ module Transit
       def from_rep(v) v.to_i end
     end
     class BigDecimalHandler
-      def from_rep(v) BigDecimal.new(v) end
+      def from_rep(v) BigDecimal(v) end
     end
     class SpecialNumbersHandler
       def from_rep(v)

--- a/spec/transit/round_trip_spec.rb
+++ b/spec/transit/round_trip_spec.rb
@@ -110,7 +110,7 @@ module Transit
     round_trips("NaN", Float::NAN, type)
     round_trips("Infinity", Float::INFINITY, type)
     round_trips("-Infinity", -Float::INFINITY, type)
-    round_trips("a bigdec", BigDecimal.new("123.45"), type)
+    round_trips("a bigdec", BigDecimal("123.45"), type)
     round_trips("an instant (DateTime local)", DateTime.new(2014,1,2,3,4,5, "-5"), type,
                 :expected => DateTime.new(2014,1,2, (3+5) ,4,5, "+00:00"))
     round_trips("an instant (DateTime gmt)", DateTime.new(2014,1,2,3,4,5), type)


### PR DESCRIPTION
Fixes #25 